### PR TITLE
Fix typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ with known vulnerabilities.
 
 # newsletter / cleantech
 
-I am publishing the Industry Decarbonization
-Newsletter](https://industrydecarbonization.com/) about cleantech and climate solutions.
+I am publishing the [Industry Decarbonization Newsletter](https://industrydecarbonization.com/)
+about cleantech and climate solutions.
 
 Here are some recent articles published there you may find interesting:
 


### PR DESCRIPTION
Hey, you've got a typo/Markdown syntax error here, maybe due to the line wrapping, but the starting `[` was missing, in any case.